### PR TITLE
Fix imports spread across multiple blocks

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -152,12 +152,12 @@ export const extractImports = (root: t.File) => {
 };
 
 export const plugin = (store: any) => (root: any) => {
-  const imports = root.children.find((child: any) => child.type === 'mdxjsEsm');
+  const esmBlocks: any[] = root.children.filter((child: any) => child.type === 'mdxjsEsm');
 
-  let varToImport = {};
-  if (imports) {
-    varToImport = extractImports(toBabel(imports.data.estree));
-  }
+  const varToImport = esmBlocks.reduce((acc, block) => {
+    const imports = extractImports(toBabel(block.data.estree));
+    return { ...acc, ...imports };
+  }, {} as Record<string, string>);
 
   const estree = store.toEstree(root);
   const clone = cloneDeep(estree);


### PR DESCRIPTION
Issue: #6

## What Changed

The old code assumed that the first ESM block would contain the imports. New code assumes that it can be anywhere in the file and split across multiple blocks.

Also cleaned up some formatting in the tests

Self-merging @tmeasday 

## How to test

See attached tests

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [x] `patch`
- [ ] `minor`
- [ ] `major`
