### PR TITLE
Fixed exported named declarations causing @storybook/docs-mdx to throw

### DIFF
--- a/src/analyze.test.ts
+++ b/src/analyze.test.ts
@@ -42,7 +42,7 @@ describe('analyze', () => {
     it('string literal title', () => {
       const input = dedent`
         # hello
-  
+
         <Meta title="foobar" />
       `;
       expect(analyze(input)).toMatchInlineSnapshot(`
@@ -59,7 +59,7 @@ describe('analyze', () => {
     it('template literal title', () => {
       const input = dedent`
         # hello
-  
+
         <Meta title={\`foobar\`} />
       `;
       expect(() => analyze(input)).toThrowErrorMatchingInlineSnapshot(
@@ -72,7 +72,7 @@ describe('analyze', () => {
     it('string literal name', () => {
       const input = dedent`
         # hello
-  
+
         <Meta name="foobar" />
       `;
       expect(analyze(input)).toMatchInlineSnapshot(`
@@ -88,7 +88,7 @@ Object {
     it('template literal name', () => {
       const input = dedent`
         # hello
-  
+
         <Meta name={\`foobar\`} />
       `;
       expect(() => analyze(input)).toThrowErrorMatchingInlineSnapshot(
@@ -127,7 +127,7 @@ Object {
     it('string literal', () => {
       const input = dedent`
         import * as ButtonStories from './Button.stories';
-  
+
         <Meta of="foobar" />
       `;
       expect(() => analyze(input)).toThrowErrorMatchingInlineSnapshot(
@@ -181,6 +181,17 @@ Object {
           "title": undefined,
         }
       `);
+    });
+  });
+
+  describe('exported named declarations', () => {
+    it('should not throw when exporting named declarations', () => {
+      const input = dedent`
+        <Meta name="foobar" />
+        export const status = "ready";
+        export const values = [{ name: 'label' }]
+      `;
+      expect(() => analyze(input)).not.toThrow();
     });
   });
 
@@ -289,7 +300,7 @@ Object {
     it('duplicate meta, both title', () => {
       const input = dedent`
         <Meta title="foobar" />
-  
+
         <Meta title="bz" />
       `;
       expect(() => analyze(input)).toThrowErrorMatchingInlineSnapshot(
@@ -302,7 +313,7 @@ Object {
         import * as ButtonStories from './Button.stories';
 
         <Meta title="foobar" />
-  
+
         <Meta of={ButtonStories} />
       `;
       expect(() => analyze(input)).toThrowErrorMatchingInlineSnapshot(

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -152,17 +152,10 @@ export const extractImports = (root: t.File) => {
 };
 
 export const plugin = (store: any) => (root: any) => {
-  const esmBlocks: any[] = root.children.filter((child: any) => child.type === 'mdxjsEsm');
-
-  const varToImport = esmBlocks.reduce((acc, block) => {
-    const imports = extractImports(toBabel(block.data.estree));
-    return { ...acc, ...imports };
-  }, {} as Record<string, string>);
-
   const estree = store.toEstree(root);
   const clone = cloneDeep(estree);
   const babel = toBabel(clone);
-
+  const varToImport = extractImports(babel);
   const { title, of, name, isTemplate } = extractTitle(babel, varToImport);
   store.title = title;
   store.of = of;


### PR DESCRIPTION
[See relevant discussion on Discord](https://discord.com/channels/486522875931656193/1054051640946208768/1059862708851331174)

When exporting variables from MDX files, Storybook won't start and raise the following error:

![image](https://user-images.githubusercontent.com/16818271/210682995-6299fc7d-1691-4007-bd2a-16a9c77d47c8.png)

[Here is a repro](https://github.com/Dschungelabenteuer/storybook7-repro-stories/tree/main/cases/mdx-const-export)

## What Changed

There seems to be a slight gap between what [`estree-to-babel`](https://github.com/storybookjs/docs-mdx/blob/next/src/analyze.ts#L158) accepts and what is compiled by [`@mdx-js/mdx`](https://github.com/storybookjs/docs-mdx/blob/next/src/analyze.ts#L185). I've tried to dig into it, but quickly got a bit lost. Then I realized that the whole root is systematically [ran through `toBabel`](https://github.com/storybookjs/docs-mdx/blob/next/src/analyze.ts#L164) no matter what. I'm not sure the whole thing around filtered `esmBlocks` is really relevant since we could benefit from the whole tree being systematically babelized when calling `extractImports` .

Anything I might be missing? 

##  Alternatives I've considered

For now, `toBabel` is actually only used to extract imports, so we should be able to skip the ESTree conversion analysis of `ExportNamedDeclaration`s. I've tried to implement this in [this branch](https://github.com/Dschungelabenteuer/docs-mdx/tree/fix-exported-named-declarations) but hopefully the above solution works better and looks way cleaner.

## Change Type

- [ ] `maintenance`
- [ ] `documentation`
- [X] `patch`
- [ ] `minor`
- [ ] `major`
