### PR TITLE
Support summary extraction

### DIFF
--- a/src/analyze.test.ts
+++ b/src/analyze.test.ts
@@ -50,6 +50,7 @@ describe('analyze', () => {
           "metaTags": undefined,
           "name": undefined,
           "of": undefined,
+          "summary": undefined,
           "title": "foobar",
         }
       `);
@@ -80,6 +81,7 @@ describe('analyze', () => {
           "metaTags": undefined,
           "name": "foobar",
           "of": undefined,
+          "summary": undefined,
           "title": undefined,
         }
       `);
@@ -114,6 +116,7 @@ describe('analyze', () => {
           "metaTags": undefined,
           "name": undefined,
           "of": "./Button.stories",
+          "summary": undefined,
           "title": undefined,
         }
       `);
@@ -154,6 +157,7 @@ describe('analyze', () => {
           "metaTags": undefined,
           "name": undefined,
           "of": "./Button.stories",
+          "summary": undefined,
           "title": undefined,
         }
       `);
@@ -182,6 +186,7 @@ describe('analyze', () => {
           "metaTags": undefined,
           "name": "Story One",
           "of": "../src/A.stories",
+          "summary": undefined,
           "title": undefined,
         }
       `);
@@ -199,6 +204,33 @@ describe('analyze', () => {
     });
   });
 
+  describe('summary', () => {
+    it('string literal summary', async () => {
+      const input = dedent`
+        <Meta summary="This is a summary." />
+      `;
+      await expect(analyze(input)).resolves.toMatchInlineSnapshot(`
+        {
+          "imports": [],
+          "isTemplate": false,
+          "metaTags": undefined,
+          "name": undefined,
+          "of": undefined,
+          "summary": "This is a summary.",
+          "title": undefined,
+        }
+      `);
+    });
+    it('template literal summary', async () => {
+      const input = dedent`
+        <Meta summary={\`This is a summary.\`} />
+      `;
+      await expect(() => analyze(input)).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[Error: Expected string literal summary, received JSXExpressionContainer]`
+      );
+    });
+  });
+
   describe('isTemplate', () => {
     it('boolean implicit', async () => {
       const input = dedent`
@@ -211,6 +243,7 @@ describe('analyze', () => {
           "metaTags": undefined,
           "name": undefined,
           "of": undefined,
+          "summary": undefined,
           "title": undefined,
         }
       `);
@@ -226,6 +259,7 @@ describe('analyze', () => {
           "metaTags": undefined,
           "name": undefined,
           "of": undefined,
+          "summary": undefined,
           "title": undefined,
         }
       `);
@@ -241,6 +275,7 @@ describe('analyze', () => {
           "metaTags": undefined,
           "name": undefined,
           "of": undefined,
+          "summary": undefined,
           "title": undefined,
         }
       `);
@@ -285,6 +320,7 @@ describe('analyze', () => {
           ],
           "name": undefined,
           "of": "./Button.stories",
+          "summary": undefined,
           "title": undefined,
         }
       `);
@@ -327,6 +363,7 @@ describe('analyze', () => {
           "metaTags": undefined,
           "name": undefined,
           "of": undefined,
+          "summary": undefined,
           "title": undefined,
         }
       `);
@@ -346,6 +383,7 @@ describe('analyze', () => {
           "metaTags": undefined,
           "name": undefined,
           "of": undefined,
+          "summary": undefined,
           "title": undefined,
         }
       `);
@@ -389,6 +427,7 @@ describe('analyze', () => {
           "metaTags": undefined,
           "name": undefined,
           "of": "./Button.stories",
+          "summary": undefined,
           "title": undefined,
         }
       `);

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -94,10 +94,17 @@ const getIsTemplate = (elt: JSXOpeningElement): boolean => {
 };
 
 const extractTitle = (root: Program, varToImport: Record<string, string>) => {
-  const result = { title: undefined, of: undefined, name: undefined, isTemplate: false } as {
+  const result = {
+    title: undefined,
+    of: undefined,
+    name: undefined,
+    summary: undefined,
+    isTemplate: false,
+  } as {
     title: string | undefined;
     of: string | undefined;
     name: string | undefined;
+    summary: string | undefined;
     isTemplate: boolean;
     metaTags: string[] | undefined;
   };
@@ -119,6 +126,7 @@ const extractTitle = (root: Program, varToImport: Record<string, string>) => {
         }
         result.title = getAttrLiteral(openingElement, 'title');
         result.name = getAttrLiteral(openingElement, 'name');
+        result.summary = getAttrLiteral(openingElement, 'summary');
         result.of = getOf(openingElement, varToImport);
         result.isTemplate = getIsTemplate(openingElement);
         result.metaTags = getTags(openingElement);
@@ -153,10 +161,11 @@ export const extractImports = (root: Program) => {
 export const plugin = (store: any) => (root: any) => {
   const estree = toEstree(root);
   const varToImport = extractImports(estree);
-  const { title, of, name, isTemplate, metaTags } = extractTitle(estree, varToImport);
+  const { title, of, name, summary, isTemplate, metaTags } = extractTitle(estree, varToImport);
   store.title = title;
   store.of = of;
   store.name = name;
+  store.summary = summary;
   store.isTemplate = isTemplate;
   store.metaTags = metaTags;
   store.imports = Array.from(new Set(Object.values(varToImport)));
@@ -177,6 +186,6 @@ export const analyze = async (code: string) => {
   await compile(code, {
     rehypePlugins: [[plugin, store]],
   });
-  const { title, of, name, isTemplate, metaTags, imports = [] } = store;
-  return { title, of, name, isTemplate, metaTags, imports };
+  const { title, of, name, summary, isTemplate, metaTags, imports = [] } = store;
+  return { title, of, name, summary, isTemplate, metaTags, imports };
 };


### PR DESCRIPTION
Works on https://github.com/storybookjs/mcp/issues/107

## What Changed

Added support for extracting a string litteral `summary` prop on the `<Meta />`-component:

```
<Meta summary="This is the summary. it must be a string litteral" />
```

<!-- Insert a description below. -->

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->

## Change Type

<!-- Indicate the type of change your pull request is: -->

- [ ] `maintenance`
- [ ] `documentation`
- [ ] `patch`
- [x] `minor`
- [ ] `major`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.2.0--canary.20.3700111.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/docs-mdx@3.2.0--canary.20.3700111.0
  # or 
  yarn add @storybook/docs-mdx@3.2.0--canary.20.3700111.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v4.0.0-next.3`

<details>
  <summary>Changelog</summary>

  #### 💥 Breaking Change
  
  - Optimize install size [#19](https://github.com/storybookjs/docs-mdx/pull/19) ([@shilman](https://github.com/shilman))
  
  #### 🚀 Enhancement
  
  - Support summary extraction [#20](https://github.com/storybookjs/docs-mdx/pull/20) ([@JReinhold](https://github.com/JReinhold))
  
  #### 🐛 Bug Fix
  
  - Use npm trusted publishing for releases [#21](https://github.com/storybookjs/docs-mdx/pull/21) ([@JReinhold](https://github.com/JReinhold))
  
  #### ⚠️ Pushed to `next`
  
  - Remove extra console.log ([@shilman](https://github.com/shilman))
  
  #### Authors: 2
  
  - Jeppe Reinhold ([@JReinhold](https://github.com/JReinhold))
  - Michael Shilman ([@shilman](https://github.com/shilman))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
